### PR TITLE
Readme duplicate variable name in config fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ssh_security_group_ids = []
 elb_security_group_ids = []
 
 rabbitmq_admin_password = "example-password"
-rabbitmq_admin_password = "example-password"
+rabbitmq_rabbit_password = "example-password"
 rabbitmq_secret_cookie = "example-secret-cookie"
 rabbitmq_node_count = 3
 ```


### PR DESCRIPTION
Hi, it's a quick fix for the Readme,
thanks for sharing this clean compact Terraform module, will try now :) 